### PR TITLE
Partially migrate gist to omego

### DIFF
--- a/openstack/examples/00_openstack.sh
+++ b/openstack/examples/00_openstack.sh
@@ -1,0 +1,21 @@
+#!/bin/bash
+
+# This script is not needed under docker.
+
+## Mount network shares
+SMB_USER=username
+SMB_SHARE1=//orca-5.openmicroscopy.org/idr
+sudo mkdir -p /uod/idr
+sudo mount -t cifs -o username="$SMB_USER" "$SMB_SHARE1" /uod/idr
+
+if [ ! -d /uod/idr/filesets ]; then
+    echo "ERROR: IDR filesets not found, exiting"
+    exit 2
+fi
+
+# Optionally disable autostart of OMERO.server
+# because /uod/idr needs to be manually mounted
+sudo systemctl disable omero
+
+# If there are web css problems you may need to restore the SELinux labelling
+sudo restorecon -R -v ~omero/

--- a/openstack/examples/01_install.sh
+++ b/openstack/examples/01_install.sh
@@ -1,0 +1,49 @@
+#!/bin/bash
+
+# Install extra utilities
+# TODO: Use ansible
+sudo yum install -y screen
+
+sudo chmod a+x /home/*
+
+OMERO_SERVER=/home/omero/OMERO.server
+
+# Download the render.py plugin if it's not present in this build
+if [ ! -f "$OMERO_SERVER/lib/python/omero/plugins/render.py" ]; then
+    sudo -u omero sh -c "curl https://raw.githubusercontent.com/manics/openmicroscopy/metadata52-render/components/tools/OmeroPy/src/omero/plugins/render.py > '$OMERO_SERVER/lib/python/omero/plugins/render.py'"
+    sudo -u omero sh -c "curl https://raw.githubusercontent.com/manics/openmicroscopy/metadata52-render/components/tools/OmeroPy/src/omero/util/pydict_text_readers.py > '$OMERO_SERVER/lib/python/omero/util/pydict_text_readers.py'"
+fi
+
+omero="$OMERO_SERVER/bin/omero"
+
+# Setup server settings
+sudo -u omero $omero << EOF
+config set omero.db.poolsize 25
+config set omero.jvmcfg.heap_size.blitz 16G
+config set omero.sessions.timeout 3600000
+EOF
+
+# WARNING: don't use admin restart as this will break systemd control
+sudo systemctl restart omero
+sleep 1m
+
+# Create users and groups
+PUBLIC_PASS="$(openssl rand -base64 12)"
+
+$omero login -s localhost -u root -w omero
+$omero group add --type read-only demo
+$omero user add --group-name demo -P ome demo idr demo
+$omero user add --group-name demo -P "$PUBLIC_PASS" public Public User
+$omero logout
+
+# Setup public user
+sudo -u omero $omero << EOF
+config set omero.web.public.url_filter '^/(webadmin/myphoto/|webclient/(?!(action|annotate_(file|tags|comment|rating|map)|script_ui|ome_tiff|figure_script))|webgateway/(?!(archived_files|download_as)))'
+config set omero.web.public.enabled True
+config set omero.web.public.user public
+config set omero.web.public.password "$PUBLIC_PASS"
+config set omero.web.public.server_id 1
+config set omero.web.login_redirect '{"redirect": ["webindex"], "viewname": "load_template", "args":["userdata"], "query_string": "experimenter=2"}'
+EOF
+# WARNING: don't use admin restart as this will break systemd control
+sudo systemctl restart omero-web

--- a/openstack/examples/Dockerfile
+++ b/openstack/examples/Dockerfile
@@ -1,0 +1,3 @@
+FROM openmicroscopy/omero-ssh-systemd
+
+COPY *.sh /tmp/

--- a/openstack/examples/Makefile
+++ b/openstack/examples/Makefile
@@ -1,10 +1,30 @@
 NAME := mini-idr
+UID := $(shell echo $$UID)
 
 ssh:
-	ssh omero@$$(docker inspect --format '{{.NetworkSettings.IPAddress}}' $(NAME))
+	ssh -qt \
+		-o UserKnownHostsFile=/dev/null \
+		-o StrictHostKeyChecking=no \
+		omero@$$(docker inspect --format '{{.NetworkSettings.IPAddress}}' $(NAME))
+
+config:
+	docker exec -u root $(NAME) usermod -u $(UID) omero
+	docker exec -u root $(NAME) chown -R omero /home/omero
+	docker exec -u root $(NAME) bash -eux /tmp/idr-example-omero-bootstrap.sh
+	docker exec -u omero $(NAME) bash -eux /tmp/idr-setup-1.sh
 
 run: build
-	docker run -d --name $(NAME) -v /run -v /sys/fs/cgroup:/sys/fs/cgroup:ro $(NAME)
+	docker run -d \
+		-p 58888:80 \
+		-p 54064:4064 \
+		-p 54063:4063 \
+		--cap-add SYS_ADMIN \
+		--name $(NAME) \
+		-v /run \
+		-v /sys/fs/cgroup:/sys/fs/cgroup:ro \
+		-v /uod:/uod:ro \
+		-v /uod/idr/versions/mini-idr:/OMERO \
+		$(NAME)
 	echo See: $$(docker inspect --format '{{.NetworkSettings.IPAddress}}' $(NAME))
 
 build:

--- a/openstack/examples/Makefile
+++ b/openstack/examples/Makefile
@@ -1,0 +1,15 @@
+NAME := mini-idr
+
+ssh:
+	ssh omero@$$(docker inspect --format '{{.NetworkSettings.IPAddress}}' $(NAME))
+
+run: build
+	docker run -d --name $(NAME) -v /run -v /sys/fs/cgroup:/sys/fs/cgroup:ro $(NAME)
+	echo See: $$(docker inspect --format '{{.NetworkSettings.IPAddress}}' $(NAME))
+
+build:
+	docker build -t $(NAME) .
+
+clean:
+	docker stop $(NAME)
+	docker rm $(NAME)

--- a/openstack/examples/Makefile
+++ b/openstack/examples/Makefile
@@ -11,7 +11,7 @@ config:
 	docker exec -u root $(NAME) usermod -u $(UID) omero
 	docker exec -u root $(NAME) chown -R omero /home/omero
 	docker exec -u root $(NAME) bash -eux /tmp/idr-example-omero-bootstrap.sh
-	docker exec -u omero $(NAME) bash -eux /tmp/idr-setup-1.sh
+	docker exec -u omero $(NAME) bash -eux /tmp/01_install.sh
 
 run: build
 	docker run -d \

--- a/openstack/examples/idr-example-omero-bootstrap.sh
+++ b/openstack/examples/idr-example-omero-bootstrap.sh
@@ -20,6 +20,7 @@ EOF
 
 export ANSIBLE_ROLES_PATH=/opt/infrastructure/ansible/roles
 /opt/ansible/bin/ansible-playbook /opt/infrastructure/openstack/examples/idr-example-omero.yml \
-    --extra-vars @/opt/infrastructure/localhost-extravars.yml 2>&1
+    --extra-vars "omero_selinux_setup=False @/opt/infrastructure/localhost-extravars.yml" 2>&1
+
 
 exit 0

--- a/openstack/examples/idr-example-omero-bootstrap.sh
+++ b/openstack/examples/idr-example-omero-bootstrap.sh
@@ -24,7 +24,7 @@ EOF
 
 export ANSIBLE_ROLES_PATH=/opt/infrastructure/ansible/roles
 /opt/ansible/bin/ansible-playbook /opt/infrastructure/openstack/examples/idr-example-omero.yml \
-    --extra-vars "omero_selinux_setup=False @/opt/infrastructure/localhost-extravars.yml" 2>&1
+    --extra-vars "omero_release=OMERO-DEV-merge-build omero_selinux_setup=False @/opt/infrastructure/localhost-extravars.yml" 2>&1
 
 
 exit 0

--- a/openstack/examples/idr-example-omero-bootstrap.sh
+++ b/openstack/examples/idr-example-omero-bootstrap.sh
@@ -4,12 +4,16 @@ set -e
 
 # gcc needed for ansible dependencies
 yum install -q -y git python-virtualenv gcc 2>&1
-virtualenv -q --system-site-packages /opt/ansible 2>&1
-/opt/ansible/bin/pip -q install ansible 2>&1
+
+if [ ! -d /opt/ansible ];
+then
+  virtualenv -q --system-site-packages /opt/ansible 2>&1
+  /opt/ansible/bin/pip -q install ansible 2>&1
+fi
 
 cd /opt
 
-git clone -q --single-branch -b omego https://github.com/manics/infrastructure.git /opt/infrastructure 2>&1
+[ -d /opt/infrastructure ] || git clone -q --single-branch -b omego https://github.com/manics/infrastructure.git /opt/infrastructure 2>&1
 
 # Custom variable overrides (YAML, can be empty)
 cat << EOF > /opt/infrastructure/localhost-extravars.yml


### PR DESCRIPTION
This PR splits splits out part of the mini-idr gist and includes it in the dependent omego PR (https://github.com/openmicroscopy/infrastructure/pull/61). Once this PR and 61 are merged, the scripts will need to be updated to remove the explicit use of `git clone -b omego`.

Also, this PR over-specializes the scripts for use with Docker and on a particular OMERO build. A follow-up should clean the examples directory, splitting files as necessary and making.
